### PR TITLE
Remove redundant use which is breaking the script

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -34,12 +34,12 @@ resolvers, which you will use for the `Query` and `Mutation` roots.
 
 use juniper::{FieldResult};
 
-# struct DatabasePool;
-# impl DatabasePool {
-#     fn get_connection(&self) -> FieldResult<DatabasePool> { Ok(DatabasePool) }
-#     fn find_human(&self, id: &str) -> FieldResult<Human> { Err("")? }
-#     fn insert_human(&self, human: &NewHuman) -> FieldResult<Human> { Err("")? }
-# }
+struct DatabasePool;
+impl DatabasePool {
+    fn get_connection(&self) -> FieldResult<DatabasePool> { Ok(DatabasePool) }
+    fn find_human(&self, id: &str) -> FieldResult<Human> { Err("")? }
+    fn insert_human(&self, human: &NewHuman) -> FieldResult<Human> { Err("")? }
+}
 
 #[derive(GraphQLEnum)]
 enum Episode {

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -41,9 +41,6 @@ use juniper::{FieldResult};
 #     fn insert_human(&self, human: &NewHuman) -> FieldResult<Human> { Err("")? }
 # }
 
-
-use juniper::{FieldResult};
-
 #[derive(GraphQLEnum)]
 enum Episode {
     NewHope,


### PR DESCRIPTION
Removed redundant line: `use juniper::{FieldResult};` in the Schema Example code on /quickstart.html

edit: meant for the second commit to be a separate PR; this may be excluded by the original author intentionally as a breadcrumb for the student.