### PR TITLE
Only deploy from one job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,6 @@ deploy:
   github_token: $DEPLOY_TOKEN
   on:
     branch: source
+    rust: stable
   target_branch: master
   local_dir: _book/


### PR DESCRIPTION
We will deploy when the stable job triggered from `source` goes green