### PR TITLE
Fix moved Actix-Web link

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -28,7 +28,7 @@
   - [Rocket](servers/rocket.md)
   - [Iron](servers/iron.md)
 - Integrations by others
-  - [Actix-Web](https://github.com/actix/examples/tree/master/juniper)
+  - [Actix-Web](https://github.com/actix/examples/tree/master/graphql/juniper)
   - [Finchers](https://github.com/finchers-rs/finchers-juniper)
   - [Tsukuyomi](https://github.com/tsukuyomi-rs/tsukuyomi/tree/master/examples/juniper)
 


### PR DESCRIPTION
The Actix-Web link under "Integrations by others" has moved. I've updated the link.