### PR TITLE
Fix broken links, remove typo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,7 @@ Juniper has not reached 1.0 yet, thus some API instability should be expected.
 
 [graphql]: http://graphql.org
 [graphiql]: https://github.com/graphql/graphiql
-[iron]: http://ironframework.io
+[iron]: https://github.com/iron/iron
 [graphql_spec]: http://facebook.github.io/graphql
 [test_schema_rs]: https://github.com/graphql-rust/juniper/blob/master/juniper/src/tests/schema.rs
 [tokio]: https://github.com/tokio-rs/tokio

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -188,4 +188,4 @@ fn main() {
 [rocket]: servers/rocket.md
 [iron]: servers/iron.md
 [tutorial]: ./tutorial.html
-[jp_obj_macro]: https://docs.rs/juniper/latest/juniper/macro.graphql_object.html
+[jp_obj_macro]: https://docs.rs/juniper/latest/juniper/attr.graphql_object.html

--- a/docs/servers/hyper.md
+++ b/docs/servers/hyper.md
@@ -1,6 +1,6 @@
 # Integrating with Hyper
 
-[Hyper] is a is a fast HTTP implementation that many other Rust web frameworks
+[Hyper] is a fast HTTP implementation that many other Rust web frameworks
 leverage. It offers asynchronous I/O via the tokio runtime and works on
 Rust's stable channel.
 

--- a/docs/servers/iron.md
+++ b/docs/servers/iron.md
@@ -120,6 +120,6 @@ graphql_object!(Root: Context |&self| {
 
 FIXME: Show how the `persistent` crate works with contexts using e.g. `r2d2`.
 
-[iron]: http://ironframework.io
+[iron]: https://github.com/iron/iron
 [graphiql]: https://github.com/graphql/graphiql
 [mount]: https://github.com/iron/mount

--- a/docs/servers/warp.md
+++ b/docs/servers/warp.md
@@ -20,4 +20,4 @@ Included in the source is a [small example][example] which sets up a basic Graph
 [hyper]: https://hyper.rs/
 [warp]: https://crates.io/crates/warp
 [juniper_warp]: https://github.com/graphql-rust/juniper/tree/master/juniper_warp
-[example]: https://github.com/graphql-rust/juniper/tree/master/juniper_warp/examples/warp_server
+[example]: https://github.com/graphql-rust/juniper/tree/master/juniper_warp/examples/warp_server.rs


### PR DESCRIPTION
Iron's domain seems inactive now and links to a privnota instance instead. `graphql_object` location changed in docs, `.rs` was missing from file extension